### PR TITLE
setup ingress

### DIFF
--- a/service-template/templates/ingress.yaml
+++ b/service-template/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
 spec:
   rules:
-  - host: {{ required "service name is missing" .Values.serviceName }}-{{ required "cloud platform is missing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}.awx.onl
+  - host: {{ required "service name is missing" .Values.serviceName }}.{{ required "domain is missing" .Values.cloudProvider.domain }}.{{ required "cloud platform is missing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}.{{required "env is missing" .Values.cloudProvider.env}}.awx.im
     http:
       paths:
       - backend:
@@ -17,5 +17,5 @@ spec:
         path: /
   tls:
   - hosts:
-    - {{ required "service name is missing" .Values.serviceName }}-{{ required "cloud platform is missing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}.poc.awx.onl
-    secretName: tls-cert-{{ required "service name missing" .Values.serviceName }}-{{ required "cloud platform is missing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}
+    - {{ required "service name is missing" .Values.serviceName }}.{{ required "domain is missing" .Values.cloudProvider.domain }}.{{ required "cloud platform is missing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}.{{required "env is missing" .Values.cloudProvider.env}}.awx.im
+    secretName: tls-wildcard-{{ required "domain is missing" .Values.cloudProvider.domain }}-{{ required "cloud platform is missing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}-{{required "env is missing" .Values.cloudProvider.env}}-awx-im

--- a/service-template/templates/ingress.yaml
+++ b/service-template/templates/ingress.yaml
@@ -3,8 +3,8 @@ kind: Ingress
 metadata:
   name: {{ required "service name is missing" .Values.serviceName }}
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    kubernetes.io/ingress.class: nginx
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+    # kubernetes.io/ingress.class: nginx
     kubernetes.io/tls-acme: "true"
 spec:
   rules:
@@ -17,5 +17,5 @@ spec:
         path: /
   tls:
   - hosts:
-    - {{ required "service name is missing" .Values.serviceName }}.{{ required "domain is missing" .Values.cloudProvider.domain }}.{{ required "cloud platform is missing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}.{{required "env is missing" .Values.cloudProvider.env}}.awx.im
-    secretName: tls-wildcard-{{ required "domain is missing" .Values.cloudProvider.domain }}-{{ required "cloud platform is missing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}-{{required "env is missing" .Values.cloudProvider.env}}-awx-im
+    - "*.{{ required "domain is missing" .Values.cloudProvider.domain }}.{{ required "cloud platform is missing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}.{{required "env is missing" .Values.cloudProvider.env}}.awx.im"
+    secretName: wildcard-{{ required "domain is missing" .Values.cloudProvider.domain }}-{{ required "cloud platform is missing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}-{{required "env is missing" .Values.cloudProvider.env}}-awx-im-tls

--- a/service-template/templates/preview-ingress.yaml
+++ b/service-template/templates/preview-ingress.yaml
@@ -3,9 +3,9 @@ kind: Ingress
 metadata:
   name: {{ required "service name is missing" .Values.serviceName }}-preview
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+    # kubernetes.io/tls-acme: "true"
     kubernetes.io/ingress.class: nginx
-    kubernetes.io/tls-acme: "true"
 spec:
   rules:
   - host: {{ required "service name is missing" .Values.serviceName }}-preview.{{ required "domain is missing" .Values.cloudProvider.domain }}.{{ required "cloud platform is missing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}.{{required "env is missing" .Values.cloudProvider.env}}.awx.im
@@ -17,5 +17,5 @@ spec:
         path: /
   tls:
   - hosts:
-    - {{ required "service name is missing" .Values.serviceName }}-preview.{{ required "domain is missing" .Values.cloudProvider.domain }}.{{ required "cloud platform is missing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}.{{required "env is missing" .Values.cloudProvider.env}}.awx.im
-    secretName: tls-wildcard-{{ required "domain is missing" .Values.cloudProvider.domain }}-{{ required "cloud platform is missing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}-{{required "env is missing" .Values.cloudProvider.env}}-awx-im
+    - "*.{{ required "domain is missing" .Values.cloudProvider.domain }}.{{ required "cloud platform is missing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}.{{required "env is missing" .Values.cloudProvider.env}}.awx.im"
+    secretName: wildcard-{{ required "domain is missing" .Values.cloudProvider.domain }}-{{ required "cloud platform is missing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}-{{required "env is missing" .Values.cloudProvider.env}}-awx-im-tls

--- a/service-template/templates/preview-ingress.yaml
+++ b/service-template/templates/preview-ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
 spec:
   rules:
-  - host: {{ required "service name is missing" .Values.serviceName }}-{{ required "cloud platform ismissing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}-preview.poc.awx.onl
+  - host: {{ required "service name is missing" .Values.serviceName }}-preview.{{ required "domain is missing" .Values.cloudProvider.domain }}.{{ required "cloud platform is missing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}.{{required "env is missing" .Values.cloudProvider.env}}.awx.im
     http:
       paths:
       - backend:
@@ -17,5 +17,5 @@ spec:
         path: /
   tls:
   - hosts:
-    - {{ required "service name is missing" .Values.serviceName }}-{{ required "cloud platform is missing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}-preview.poc.awx.onl
-    secretName: tls-cert-{{ required "service name is missing" .Values.serviceName }}-{{ required "cloud platform is missing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}-preview
+    - {{ required "service name is missing" .Values.serviceName }}-preview.{{ required "domain is missing" .Values.cloudProvider.domain }}.{{ required "cloud platform is missing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}.{{required "env is missing" .Values.cloudProvider.env}}.awx.im
+    secretName: tls-wildcard-{{ required "domain is missing" .Values.cloudProvider.domain }}-{{ required "cloud platform is missing" .Values.cloudProvider.platform }}-{{ required "region is missing" .Values.cloudProvider.region }}-{{required "env is missing" .Values.cloudProvider.env}}-awx-im

--- a/service-values/app-validation-service/dev/gcp-sg-values.yaml
+++ b/service-values/app-validation-service/dev/gcp-sg-values.yaml
@@ -1,7 +1,11 @@
 
 cloudProvider:
+  domain: gtpn
   platform: gcp
   region: sg
+  env: dev
+
+#ingress url: svcname.gtpn.gcp-sg.dev.awx.im
 
 environment:
   AWX_DATABASE_URL: jdbc:postgresql://10.14.201.40:5432/validation

--- a/service-values/app-validation-service/values.yaml
+++ b/service-values/app-validation-service/values.yaml
@@ -1,5 +1,5 @@
 
-serviceName: app-validation-service
+serviceName: appvalidationservice
 servicePort: 8080
 
 image:


### PR DESCRIPTION
1. serviceName should not contain '-' , like appvalidationservice
2. ingress URL should like `svcname.gtpn.gcp-sg.dev.awx.im`
3. Use wildcard tls cert.

```
helm template ./service-template -f service-values/app-validation-service/values.yaml -f service-values/app-validation-service/dev/gcp-sg-values.yaml -f service-values/app-validation-service/dev/values.yaml | grep "Ingress" -A 20
kkind: Ingress
metadata:
  name: appvalidationservice
  annotations:
    # cert-manager.io/cluster-issuer: letsencrypt-prod
    # kubernetes.io/ingress.class: nginx
    kubernetes.io/tls-acme: "true"
spec:
  rules:
  - host: appvalidationservice.gtpn.gcp-sg.dev.awx.im
    http:
      paths:
      - backend:
          serviceName: appvalidationservice
          servicePort: http
        path: /
  tls:
  - hosts:
    - "*.gtpn.gcp-sg.dev.awx.im"
    secretName: wildcard-gtpn-gcp-sg-dev-awx-im-tls
---
--
kind: Ingress
metadata:
  name: appvalidationservice-preview
  annotations:
    # cert-manager.io/cluster-issuer: letsencrypt-prod
    # kubernetes.io/tls-acme: "true"
    kubernetes.io/ingress.class: nginx
spec:
  rules:
  - host: appvalidationservice-preview.gtpn.gcp-sg.dev.awx.im
    http:
      paths:
      - backend:
          serviceName: appvalidationservice-preview
          servicePort: http
        path: /
  tls:
  - hosts:
    - "*.gtpn.gcp-sg.dev.awx.im"
    secretName: wildcard-gtpn-gcp-sg-dev-awx-im-tls
```